### PR TITLE
fix: パストラバーサル対策 closes #4

### DIFF
--- a/claude_log_viewer/main.py
+++ b/claude_log_viewer/main.py
@@ -223,7 +223,9 @@ def list_sessions():
 @app.get("/api/sessions/{project_dir}/{session_id}")
 def get_session(project_dir: str, session_id: str):
     for log_dir in get_log_dirs():
-        path = log_dir / project_dir / f"{session_id}.jsonl"
+        path = (log_dir / project_dir / f"{session_id}.jsonl").resolve()
+        if not str(path).startswith(str(log_dir.resolve())):
+            raise HTTPException(status_code=400, detail="Invalid path")
         if path.exists():
             return JSONResponse(parse_session(path))
     raise HTTPException(status_code=404, detail="Session not found")


### PR DESCRIPTION
## 概要

`/api/sessions/{project_dir}/{session_id}` エンドポイントで、`../` を含むパスパラメータによってログディレクトリ外のファイルが読まれる可能性があった（パストラバーサル）。`.resolve()` で正規化した上でルートディレクトリ内に収まっているかを検証するガードを追加。

## 変更内容

- `claude_log_viewer/main.py`: `path.resolve()` + `startswith(log_dir.resolve())` でパストラバーサルをブロック。範囲外なら HTTP 400 を返す。

## チェックリスト

- [x] タチコマ検証: セキュリティ問題なし（OWASP A01 パストラバーサル対策を確認）
- [x] テスト: 対象外（手動確認済み）