### PR TITLE
[feat] 本文検索機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Claude Code automatically saves all session logs to `~/.claude/projects/`. This 
 - Chat-style timeline (user messages on the right, assistant on the left)
 - Tool calls (Bash, Read, Edit, etc.) shown as collapsible rows
 - Session list grouped by project and date, with time range display
+- **Search** — two modes: session name (incremental) and content (full-text across all sessions). Hits are highlighted in-context with jump navigation
 - Session rename support
 - Token count per session
 - **Playback mode** — replay a session with smooth bubble animations (▶ play/pause, ⏹ stop, speed slider)
@@ -120,6 +121,7 @@ Claude Code はセッションのログを自動的に `~/.claude/projects/` に
 - チャット形式のタイムライン表示（ユーザー右・AIアシスタント左）
 - ツール呼び出し（Bash, Read, Edit 等）を折りたたみ行で表示
 - プロジェクト別・日付別セッション一覧（時間帯表示付き）
+- **検索** — セッション名検索（インクリメンタル）と本文検索（全セッション横断）の2モード。ヒット箇所をハイライト表示＆ジャンプナビ付き
 - セッション名の手動変更
 - セッションごとのトークン数表示
 - **再生モード** — セッションを吹き出しアニメーションで追体験（▶ 再生/一時停止、⏹ 停止、速度スライダー）

--- a/claude_log_viewer/main.py
+++ b/claude_log_viewer/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -229,6 +230,84 @@ def get_session(project_dir: str, session_id: str):
         if path.exists():
             return JSONResponse(parse_session(path))
     raise HTTPException(status_code=404, detail="Session not found")
+
+
+@app.get("/api/search")
+def search_content(q: str = ""):
+    """Search message content across all sessions."""
+    query = q.strip().lower()
+    if not query:
+        return JSONResponse([])
+
+    results = []
+    for log_dir in get_log_dirs():
+        if not log_dir.exists():
+            continue
+        for project_dir in sorted(log_dir.iterdir()):
+            if not project_dir.is_dir():
+                continue
+            for jsonl_file in sorted(project_dir.glob("*.jsonl"),
+                                     key=lambda p: p.stat().st_mtime, reverse=True):
+                hits = _search_session(jsonl_file, query)
+                if hits:
+                    session_id = jsonl_file.stem
+                    results.append({
+                        "session_id": session_id,
+                        "project_dir": project_dir.name,
+                        "hit_count": len(hits),
+                        "hits": hits[:20],  # 1セッションあたり最大20件
+                    })
+    return JSONResponse(results)
+
+
+def _search_session(path: Path, query: str) -> list[dict]:
+    """Search a single session file for query matches in text content."""
+    hits = []
+    msg_index = -1
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if entry.get("type") not in ("user", "assistant"):
+                    continue
+                msg_index += 1
+                message = entry.get("message", {})
+                if not isinstance(message, dict):
+                    continue
+                content = message.get("content")
+                if not content:
+                    continue
+                if isinstance(content, str):
+                    content = [{"type": "text", "text": content}]
+                if not isinstance(content, list):
+                    continue
+                for c in content:
+                    if not isinstance(c, dict):
+                        continue
+                    if c.get("type") != "text":
+                        continue
+                    text = c.get("text", "")
+                    if query in text.lower():
+                        # スニペット: ヒット箇所の前後40文字
+                        idx = text.lower().index(query)
+                        start = max(0, idx - 40)
+                        end = min(len(text), idx + len(query) + 40)
+                        snippet = ("…" if start > 0 else "") + text[start:end] + ("…" if end < len(text) else "")
+                        hits.append({
+                            "msg_index": msg_index,
+                            "role": entry.get("type"),
+                            "snippet": snippet,
+                        })
+                        break  # 1メッセージにつき1ヒットで十分
+    except Exception:
+        pass
+    return hits
 
 
 @app.post("/api/sessions/{session_id}/rename")

--- a/claude_log_viewer/main.py
+++ b/claude_log_viewer/main.py
@@ -261,7 +261,11 @@ def search_content(q: str = ""):
 
 
 def _search_session(path: Path, query: str) -> list[dict]:
-    """Search a single session file for query matches in text content."""
+    """Search a single session file for query matches in text content.
+
+    msg_index must match the index in parse_session()'s messages array,
+    so we replicate the exact same filtering logic here.
+    """
     hits = []
     msg_index = -1
     try:
@@ -274,9 +278,9 @@ def _search_session(path: Path, query: str) -> list[dict]:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if entry.get("type") not in ("user", "assistant"):
+                msg_type = entry.get("type")
+                if msg_type not in ("user", "assistant"):
                     continue
-                msg_index += 1
                 message = entry.get("message", {})
                 if not isinstance(message, dict):
                     continue
@@ -287,24 +291,37 @@ def _search_session(path: Path, query: str) -> list[dict]:
                     content = [{"type": "text", "text": content}]
                 if not isinstance(content, list):
                     continue
+
+                # Check if this entry would produce items in parse_session
+                has_items = any(
+                    isinstance(c, dict) and (
+                        (c.get("type") == "text" and c.get("text"))
+                        or c.get("type") in ("tool_use", "tool_result")
+                    )
+                    for c in content
+                )
+                if not has_items:
+                    continue
+
+                # Only count messages that parse_session would include
+                msg_index += 1
+
+                # Search text content
                 for c in content:
-                    if not isinstance(c, dict):
-                        continue
-                    if c.get("type") != "text":
+                    if not isinstance(c, dict) or c.get("type") != "text":
                         continue
                     text = c.get("text", "")
                     if query in text.lower():
-                        # スニペット: ヒット箇所の前後40文字
                         idx = text.lower().index(query)
                         start = max(0, idx - 40)
                         end = min(len(text), idx + len(query) + 40)
                         snippet = ("…" if start > 0 else "") + text[start:end] + ("…" if end < len(text) else "")
                         hits.append({
                             "msg_index": msg_index,
-                            "role": entry.get("type"),
+                            "role": msg_type,
                             "snippet": snippet,
                         })
-                        break  # 1メッセージにつき1ヒットで十分
+                        break
     except Exception:
         pass
     return hits

--- a/claude_log_viewer/main.py
+++ b/claude_log_viewer/main.py
@@ -236,7 +236,7 @@ def get_session(project_dir: str, session_id: str):
 def search_content(q: str = ""):
     """Search message content across all sessions."""
     query = q.strip().lower()
-    if not query:
+    if not query or len(query) < 2:
         return JSONResponse([])
 
     results = []
@@ -255,7 +255,7 @@ def search_content(q: str = ""):
                         "session_id": session_id,
                         "project_dir": project_dir.name,
                         "hit_count": len(hits),
-                        "hits": hits[:20],  # 1セッションあたり最大20件
+                        "hits": hits[:20],
                     })
     return JSONResponse(results)
 

--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -46,6 +46,9 @@
         .dark .speed-slider::-webkit-slider-thumb { background: #d97d54; }
         .speed-slider::-webkit-slider-thumb { background: #d97d54; }
 
+        /* Line clamp fallback */
+        .line-clamp-2 { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+
         /* Search highlight */
         mark.search-hit { background: #fbbf24; color: #000; border-radius: 2px; padding: 0 1px; }
         .dark mark.search-hit { background: #b45309; color: #fff; }
@@ -315,21 +318,21 @@
         return '';
     }
 
-    function renderMessage(msg) {
+    function renderMessage(msg, index) {
         const isUser = msg.role === 'user';
         const ts = msg.timestamp ? new Date(msg.timestamp).toLocaleTimeString(lang === 'ja' ? 'ja-JP' : 'en-US', {hour:'2-digit', minute:'2-digit'}) : '';
 
         if (isUser) {
             const textItems = msg.items.filter(i => i.type === 'text');
             if (!textItems.length) return '';
-            return `<div class="flex flex-col self-end max-w-[75%] items-end">
+            return `<div class="flex flex-col self-end max-w-[75%] items-end" data-msg-index="${index}">
                 <div class="text-[10px] font-mono text-zinc-400 mb-1">${ts}</div>
                 <div class="bg-zinc-50 dark:bg-zinc-800/40 border border-zinc-200 dark:border-zinc-700/60 rounded-2xl rounded-tr-sm px-4 py-3 text-sm text-zinc-800 dark:text-zinc-200 leading-relaxed whitespace-pre-wrap">${escapeHtml(textItems.map(i=>i.text).join('\n'))}</div>
             </div>`;
         } else {
             const itemsHtml = msg.items.map(renderItem).join('');
             if (!itemsHtml.trim()) return '';
-            return `<div class="flex flex-col self-start max-w-[85%] w-full relative pl-9">
+            return `<div class="flex flex-col self-start max-w-[85%] w-full relative pl-9" data-msg-index="${index}">
                 <div class="absolute left-0 top-0 w-6 h-6 flex items-center justify-center rounded-md bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
                     <i class="ph ph-robot text-anthropic text-sm"></i>
                 </div>
@@ -634,22 +637,60 @@
 
     function renderSidebar(sessions) {
         const query = document.getElementById('search').value.toLowerCase();
-        let filtered;
 
+        // Content search mode: render search results view
         if (searchMode === 'content' && contentSearchResults) {
-            // Content search mode: show only sessions with hits
-            const hitSessionIds = new Set(contentSearchResults.map(r => r.session_id));
-            filtered = sessions.filter(s => hitSessionIds.has(s.id));
-        } else if (searchMode === 'session' && query) {
-            // Session name mode: incremental filter (existing behavior)
-            filtered = sessions.filter(s =>
-                s.display_name.toLowerCase().includes(query) ||
-                s.first_text.toLowerCase().includes(query) ||
-                s.project.toLowerCase().includes(query));
-        } else {
-            filtered = sessions;
+            renderSearchResults(sessions);
+            return;
         }
 
+        // Session name mode: incremental filter (existing behavior)
+        const filtered = query
+            ? sessions.filter(s =>
+                s.display_name.toLowerCase().includes(query) ||
+                s.first_text.toLowerCase().includes(query) ||
+                s.project.toLowerCase().includes(query))
+            : sessions;
+
+        renderSessionList(filtered);
+    }
+
+    function renderSearchResults(sessions) {
+        const sessionMap = {};
+        sessions.forEach(s => { sessionMap[s.id] = s; });
+
+        let html = '';
+        contentSearchResults.forEach(result => {
+            const session = sessionMap[result.session_id];
+            if (!session) return;
+            const name20 = session.display_name.length > 20 ? session.display_name.slice(0, 20) + '…' : session.display_name;
+            const isActive = currentSession && currentSession.id === session.id;
+
+            html += `<div class="mx-2 mb-2">
+                <div class="flex items-center gap-1.5 px-2 py-1.5 rounded-md ${isActive ? 'bg-white dark:bg-zinc-700/60 border border-zinc-200 dark:border-zinc-600' : 'bg-zinc-200/70 dark:bg-zinc-700/40 border border-zinc-300/50 dark:border-zinc-600/30'}">
+                    <i class="ph ph-chat-dots text-[11px] text-zinc-500 dark:text-zinc-400 flex-shrink-0"></i>
+                    <span class="text-[11px] font-medium ${isActive ? 'text-zinc-900 dark:text-zinc-100' : 'text-zinc-700 dark:text-zinc-200'} truncate" title="${escapeHtml(session.display_name)}">${escapeHtml(name20)}</span>
+                    <span class="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 ml-auto flex-shrink-0">${result.hit_count} hits</span>
+                </div>`;
+
+            result.hits.forEach(hit => {
+                const sessionJson = escapeHtml(JSON.stringify(session));
+                const roleIcon = hit.role === 'user' ? 'ph-user' : 'ph-robot';
+                const roleColor = hit.role === 'user' ? 'text-blue-400' : 'text-anthropic';
+                html += `<div class="flex gap-1.5 px-3 py-1.5 cursor-pointer rounded hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
+                    onclick='selectSearchHit(${sessionJson}, ${hit.msg_index})'>
+                    <i class="ph ${roleIcon} ${roleColor} text-[10px] mt-0.5 flex-shrink-0"></i>
+                    <span class="text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-2">${escapeHtml(hit.snippet)}</span>
+                </div>`;
+            });
+
+            html += `</div>`;
+        });
+
+        document.getElementById('session-list').innerHTML = html || `<div class="text-xs text-zinc-400 px-4 py-4">No results</div>`;
+    }
+
+    function renderSessionList(filtered) {
         const byProject = groupSessions(filtered);
         let html = '';
 
@@ -706,6 +747,22 @@
 
     function selectSession(session) {
         loadSession(session);
+    }
+
+    async function selectSearchHit(session, msgIndex) {
+        // Load session if not already loaded
+        if (!currentSession || currentSession.id !== session.id) {
+            await loadSession(session);
+        }
+        // Find the target message by data-msg-index attribute
+        const target = document.querySelector(`[data-msg-index="${msgIndex}"]`);
+        if (target) {
+            target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            // Brief flash effect
+            target.classList.add('ring-2', 'ring-anthropic/50', 'rounded-lg');
+            setTimeout(() => target.classList.remove('ring-2', 'ring-anthropic/50', 'rounded-lg'), 2000);
+        }
+        renderSidebar(allSessions);
     }
 
     let reloading = false;

--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -456,8 +456,8 @@
             el.classList.add('msg-visible');
         });
 
-        // Apply search highlights if content search is active
-        if (searchMode === 'content' && contentSearchQuery) {
+        // Apply search highlights if content search is active (2+ chars only)
+        if (searchMode === 'content' && contentSearchQuery && contentSearchQuery.length >= 2) {
             applyHighlights(contentSearchQuery);
         }
     }
@@ -516,7 +516,7 @@
             // Show hit count
             const totalHits = results.reduce((sum, r) => sum + r.hit_count, 0);
             const hitCountEl = document.getElementById('search-hit-count');
-            hitCountEl.textContent = `${results.length} ${lang === 'ja' ? 'セッション' : 'sessions'} / ${totalHits} ${lang === 'ja' ? '件' : 'hits'}`;
+            hitCountEl.textContent = `${results.length} sessions / ${totalHits} hits`;
             hitCountEl.classList.remove('hidden');
 
             renderSidebar(allSessions);
@@ -535,6 +535,7 @@
 
     function applyHighlights(query) {
         if (!query) return;
+        clearHighlights();
         const chat = document.getElementById('chat');
         const walker = document.createTreeWalker(chat, NodeFilter.SHOW_TEXT, null);
         const textNodes = [];
@@ -578,7 +579,7 @@
         if (currentHighlightIndex >= 0) {
             counter.textContent = `${currentHighlightIndex + 1}/${marks.length}`;
         } else {
-            counter.textContent = `${marks.length} ${lang === 'ja' ? '件' : 'hits'}`;
+            counter.textContent = `${marks.length} hits`;
         }
     }
 
@@ -674,11 +675,10 @@
                 </div>`;
 
             result.hits.forEach(hit => {
-                const sessionJson = escapeHtml(JSON.stringify(session));
                 const roleIcon = hit.role === 'user' ? 'ph-user' : 'ph-robot';
                 const roleColor = hit.role === 'user' ? 'text-blue-400' : 'text-anthropic';
-                html += `<div class="flex gap-1.5 px-3 py-1.5 cursor-pointer rounded hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
-                    onclick='selectSearchHit(${sessionJson}, ${hit.msg_index})'>
+                html += `<div class="search-hit-item flex gap-1.5 px-3 py-1.5 cursor-pointer rounded hover:bg-zinc-100 dark:hover:bg-zinc-800/50 transition-colors"
+                    data-session-id="${escapeHtml(session.id)}" data-project-dir="${escapeHtml(session.project_dir)}" data-msg-index="${hit.msg_index}">
                     <i class="ph ${roleIcon} ${roleColor} text-[10px] mt-0.5 flex-shrink-0"></i>
                     <span class="text-[11px] text-zinc-500 dark:text-zinc-400 leading-snug line-clamp-2">${escapeHtml(hit.snippet)}</span>
                 </div>`;
@@ -749,26 +749,40 @@
         loadSession(session);
     }
 
-    async function selectSearchHit(session, msgIndex) {
-        // Load session if not already loaded
+    async function selectSearchHit(sessionId, projectDir, msgIndex) {
+        const session = allSessions.find(s => s.id === sessionId && s.project_dir === projectDir);
+        if (!session) return;
+
+        // Load session only if different from current
         if (!currentSession || currentSession.id !== session.id) {
             await loadSession(session);
         }
-        // Find the target message by data-msg-index attribute
+
+        // Scroll to target message
         const target = document.querySelector(`[data-msg-index="${msgIndex}"]`);
         if (target) {
+            // Clear previous flash
+            document.querySelectorAll('.ring-2.ring-anthropic\\/50').forEach(el => {
+                el.classList.remove('ring-2', 'ring-anthropic/50', 'rounded-lg');
+            });
             target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            // Brief flash effect
             target.classList.add('ring-2', 'ring-anthropic/50', 'rounded-lg');
             setTimeout(() => target.classList.remove('ring-2', 'ring-anthropic/50', 'rounded-lg'), 2000);
         }
-        renderSidebar(allSessions);
     }
 
     let reloading = false;
     async function reloadSessions() {
         if (reloading) return;
         reloading = true;
+        // Reset search state
+        contentSearchResults = null;
+        contentSearchQuery = '';
+        document.getElementById('search').value = '';
+        document.getElementById('search-hit-count').classList.add('hidden');
+        clearHighlights();
+        if (searchMode === 'content') setSearchMode('session');
+
         const btn = document.getElementById('reload-btn');
         const icon = btn.querySelector('i');
         icon.classList.add('animate-spin');
@@ -880,6 +894,12 @@
     document.getElementById('rename-input').addEventListener('input', updateRenameCount);
     document.getElementById('rename-input').addEventListener('keydown', e => { if (e.key === 'Enter') saveRename(); if (e.key === 'Escape') document.getElementById('rename-modal').classList.add('hidden'); });
     document.getElementById('reload-btn').addEventListener('click', reloadSessions);
+    document.getElementById('session-list').addEventListener('click', (e) => {
+        const item = e.target.closest('.search-hit-item');
+        if (item) {
+            selectSearchHit(item.dataset.sessionId, item.dataset.projectDir, parseInt(item.dataset.msgIndex));
+        }
+    });
     document.getElementById('playback-btn').addEventListener('click', togglePlayback);
     document.getElementById('stop-btn').addEventListener('click', playbackStop);
     document.getElementById('speed-slider').addEventListener('input', (e) => {

--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -45,6 +45,12 @@
         .speed-slider { background: #d4d4d8; }
         .dark .speed-slider::-webkit-slider-thumb { background: #d97d54; }
         .speed-slider::-webkit-slider-thumb { background: #d97d54; }
+
+        /* Search highlight */
+        mark.search-hit { background: #fbbf24; color: #000; border-radius: 2px; padding: 0 1px; }
+        .dark mark.search-hit { background: #b45309; color: #fff; }
+        mark.search-hit.current { background: #f97316; }
+        .dark mark.search-hit.current { background: #ea580c; }
     </style>
 </head>
 <body class="flex h-full overflow-hidden bg-white dark:bg-[#09090b] text-zinc-800 dark:text-zinc-300 transition-colors duration-300">
@@ -55,14 +61,26 @@
             <i class="ph-fill ph-terminal-window text-anthropic text-xl"></i>
             <span class="font-semibold text-sm text-zinc-800 dark:text-zinc-100" data-i18n="title">Claude Log Viewer</span>
         </div>
-        <div class="p-3 border-b border-zinc-200 dark:border-zinc-800 flex gap-2">
-            <div class="relative flex-1">
-                <i class="ph ph-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm"></i>
-                <input id="search" type="text" class="w-full bg-white dark:bg-zinc-950 border border-zinc-300 dark:border-zinc-800 rounded-md py-1.5 pl-8 pr-3 text-xs text-zinc-800 dark:text-zinc-300 placeholder-zinc-400 font-mono focus:outline-none focus:border-zinc-400 dark:focus:border-zinc-600 transition-colors" data-i18n-placeholder="search_placeholder">
+        <div class="border-b border-zinc-200 dark:border-zinc-800">
+            <div class="flex px-3 pt-2 gap-1">
+                <button id="search-tab-session" class="search-tab flex-1 text-[11px] font-medium py-1 rounded-t-md transition-colors border-b-2 border-anthropic text-zinc-800 dark:text-zinc-100" onclick="setSearchMode('session')">
+                    <span data-i18n="search_tab_session">セッション名</span>
+                </button>
+                <button id="search-tab-content" class="search-tab flex-1 text-[11px] font-medium py-1 rounded-t-md transition-colors border-b-2 border-transparent text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-400" onclick="setSearchMode('content')">
+                    <span data-i18n="search_tab_content">本文</span>
+                </button>
+                <button id="reload-btn" class="flex-shrink-0 p-1 rounded-md text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-200 dark:hover:bg-zinc-800 transition-colors" title="Reload sessions">
+                    <i class="ph ph-arrows-clockwise text-sm"></i>
+                </button>
             </div>
-            <button id="reload-btn" class="flex-shrink-0 p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-200 dark:hover:bg-zinc-800 transition-colors" title="Reload sessions">
-                <i class="ph ph-arrows-clockwise text-base"></i>
-            </button>
+            <div class="px-3 py-2 flex gap-2">
+                <div class="relative flex-1">
+                    <i id="search-icon" class="ph ph-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm"></i>
+                    <i id="search-spinner" class="ph ph-spinner ph-spin absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400 text-sm hidden"></i>
+                    <input id="search" type="text" class="w-full bg-white dark:bg-zinc-950 border border-zinc-300 dark:border-zinc-800 rounded-md py-1.5 pl-8 pr-3 text-xs text-zinc-800 dark:text-zinc-300 placeholder-zinc-400 font-mono focus:outline-none focus:border-zinc-400 dark:focus:border-zinc-600 transition-colors" data-i18n-placeholder="search_placeholder">
+                </div>
+            </div>
+            <div id="search-hit-count" class="hidden px-3 pb-2 text-[10px] font-mono text-zinc-400"></div>
         </div>
         <div id="session-list" class="flex-1 overflow-y-auto py-2">
             <div class="text-xs text-zinc-400 px-4 py-4" data-i18n="loading">Loading...</div>
@@ -100,10 +118,24 @@
             </div>
         </header>
 
-        <div id="chat" class="flex-1 overflow-y-auto px-10 py-8 flex flex-col gap-6">
-            <div class="flex flex-col items-center justify-center h-full text-zinc-400 dark:text-zinc-600 text-sm gap-2">
-                <i class="ph ph-chat-dots text-4xl"></i>
-                <span data-i18n="empty_state">Select a session from the sidebar</span>
+        <div class="relative flex-1 min-h-0">
+            <div id="chat" class="h-full overflow-y-auto px-10 py-8 flex flex-col gap-6">
+                <div class="flex flex-col items-center justify-center h-full text-zinc-400 dark:text-zinc-600 text-sm gap-2">
+                    <i class="ph ph-chat-dots text-4xl"></i>
+                    <span data-i18n="empty_state">Select a session from the sidebar</span>
+                </div>
+            </div>
+            <div id="highlight-nav" class="hidden absolute bottom-4 right-6 flex items-center gap-1.5 bg-white dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 rounded-lg shadow-lg px-3 py-1.5 z-20">
+                <span id="highlight-counter" class="text-xs font-mono text-zinc-500 dark:text-zinc-400 min-w-[3ch] text-center"></span>
+                <button onclick="jumpHighlight(-1)" class="p-1 rounded text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" title="Previous hit">
+                    <i class="ph ph-caret-up text-base"></i>
+                </button>
+                <button onclick="jumpHighlight(1)" class="p-1 rounded text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" title="Next hit">
+                    <i class="ph ph-caret-down text-base"></i>
+                </button>
+                <button onclick="clearHighlights()" class="p-1 rounded text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" title="Clear">
+                    <i class="ph ph-x text-base"></i>
+                </button>
             </div>
         </div>
     </main>
@@ -132,6 +164,9 @@
         en: {
             title: "Claude Log Viewer", loading: "Loading...",
             search_placeholder: "Search by session name...",
+            search_placeholder_content: "Search in messages (Enter)",
+            search_tab_session: "Session Name",
+            search_tab_content: "Content",
             rename_title: "Rename Session", cancel: "Cancel", save: "Save",
             select_session: "Select a session",
             empty_state: "Select a session from the sidebar",
@@ -148,6 +183,9 @@
         ja: {
             title: "Claude ログビューアー", loading: "読み込み中...",
             search_placeholder: "セッション名から検索...",
+            search_placeholder_content: "本文を検索（Enter）",
+            search_tab_session: "セッション名",
+            search_tab_content: "本文",
             rename_title: "セッション名を変更", cancel: "キャンセル", save: "保存",
             select_session: "セッションを選択",
             empty_state: "サイドバーからセッションを選択してください",
@@ -169,6 +207,12 @@
     // Track collapsed state per project key
     const collapsedProjects = new Set();
 
+    // Search state
+    let searchMode = 'session'; // 'session' | 'content'
+    let contentSearchResults = null; // [{session_id, project_dir, hit_count, hits}]
+    let currentHighlightIndex = -1;
+    let contentSearchQuery = '';
+
     // Playback state: 'idle' | 'playing' | 'paused'
     let playbackState = 'idle';
     let playbackTimer = null;
@@ -182,6 +226,13 @@
         document.querySelectorAll('[data-i18n-placeholder]').forEach(el => el.placeholder = t(el.dataset.i18nPlaceholder));
         document.getElementById('lang-toggle').textContent = lang === 'en' ? 'JA' : 'EN';
         document.documentElement.lang = lang;
+        // Update search placeholder based on current mode
+        updateSearchPlaceholder();
+    }
+
+    function updateSearchPlaceholder() {
+        const input = document.getElementById('search');
+        input.placeholder = searchMode === 'session' ? t('search_placeholder') : t('search_placeholder_content');
     }
 
     function toolLabel(name) {
@@ -401,6 +452,162 @@
             el.setAttribute('data-msg', '1');
             el.classList.add('msg-visible');
         });
+
+        // Apply search highlights if content search is active
+        if (searchMode === 'content' && contentSearchQuery) {
+            applyHighlights(contentSearchQuery);
+        }
+    }
+
+    // --- Search mode & content search ---
+
+    function setSearchMode(mode) {
+        searchMode = mode;
+        const sessionTab = document.getElementById('search-tab-session');
+        const contentTab = document.getElementById('search-tab-content');
+        const input = document.getElementById('search');
+
+        if (mode === 'session') {
+            sessionTab.classList.add('border-anthropic', 'text-zinc-800', 'dark:text-zinc-100');
+            sessionTab.classList.remove('border-transparent', 'text-zinc-400');
+            contentTab.classList.remove('border-anthropic', 'text-zinc-800', 'dark:text-zinc-100');
+            contentTab.classList.add('border-transparent', 'text-zinc-400');
+            // Clear content search state
+            contentSearchResults = null;
+            contentSearchQuery = '';
+            clearHighlights();
+            document.getElementById('search-hit-count').classList.add('hidden');
+        } else {
+            contentTab.classList.add('border-anthropic', 'text-zinc-800', 'dark:text-zinc-100');
+            contentTab.classList.remove('border-transparent', 'text-zinc-400');
+            sessionTab.classList.remove('border-anthropic', 'text-zinc-800', 'dark:text-zinc-100');
+            sessionTab.classList.add('border-transparent', 'text-zinc-400');
+        }
+
+        input.value = '';
+        updateSearchPlaceholder();
+        renderSidebar(allSessions);
+        input.focus();
+    }
+
+    async function executeContentSearch(query) {
+        if (!query.trim()) {
+            contentSearchResults = null;
+            contentSearchQuery = '';
+            document.getElementById('search-hit-count').classList.add('hidden');
+            clearHighlights();
+            renderSidebar(allSessions);
+            return;
+        }
+
+        // Show spinner
+        document.getElementById('search-icon').classList.add('hidden');
+        document.getElementById('search-spinner').classList.remove('hidden');
+
+        try {
+            const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+            const results = await res.json();
+            contentSearchResults = results;
+            contentSearchQuery = query;
+
+            // Show hit count
+            const totalHits = results.reduce((sum, r) => sum + r.hit_count, 0);
+            const hitCountEl = document.getElementById('search-hit-count');
+            hitCountEl.textContent = `${results.length} ${lang === 'ja' ? 'セッション' : 'sessions'} / ${totalHits} ${lang === 'ja' ? '件' : 'hits'}`;
+            hitCountEl.classList.remove('hidden');
+
+            renderSidebar(allSessions);
+
+            // If a session is currently open, apply highlights
+            if (currentSession && contentSearchQuery) {
+                applyHighlights(contentSearchQuery);
+            }
+        } catch (e) {
+            console.error('Content search failed:', e);
+        } finally {
+            document.getElementById('search-spinner').classList.add('hidden');
+            document.getElementById('search-icon').classList.remove('hidden');
+        }
+    }
+
+    function applyHighlights(query) {
+        if (!query) return;
+        const chat = document.getElementById('chat');
+        const walker = document.createTreeWalker(chat, NodeFilter.SHOW_TEXT, null);
+        const textNodes = [];
+        while (walker.nextNode()) textNodes.push(walker.currentNode);
+
+        const lowerQuery = query.toLowerCase();
+        textNodes.forEach(node => {
+            const text = node.textContent;
+            const lowerText = text.toLowerCase();
+            if (!lowerText.includes(lowerQuery)) return;
+
+            const frag = document.createDocumentFragment();
+            let lastIdx = 0;
+            let idx = lowerText.indexOf(lowerQuery, lastIdx);
+            while (idx !== -1) {
+                if (idx > lastIdx) frag.appendChild(document.createTextNode(text.slice(lastIdx, idx)));
+                const mark = document.createElement('mark');
+                mark.className = 'search-hit';
+                mark.textContent = text.slice(idx, idx + query.length);
+                frag.appendChild(mark);
+                lastIdx = idx + query.length;
+                idx = lowerText.indexOf(lowerQuery, lastIdx);
+            }
+            if (lastIdx < text.length) frag.appendChild(document.createTextNode(text.slice(lastIdx)));
+            node.parentNode.replaceChild(frag, node);
+        });
+
+        currentHighlightIndex = -1;
+        updateHighlightNav();
+    }
+
+    function updateHighlightNav() {
+        const marks = document.querySelectorAll('mark.search-hit');
+        const nav = document.getElementById('highlight-nav');
+        if (marks.length === 0) {
+            nav.classList.add('hidden');
+            return;
+        }
+        nav.classList.remove('hidden');
+        const counter = document.getElementById('highlight-counter');
+        if (currentHighlightIndex >= 0) {
+            counter.textContent = `${currentHighlightIndex + 1}/${marks.length}`;
+        } else {
+            counter.textContent = `${marks.length} ${lang === 'ja' ? '件' : 'hits'}`;
+        }
+    }
+
+    function jumpHighlight(direction) {
+        const marks = document.querySelectorAll('mark.search-hit');
+        if (marks.length === 0) return;
+
+        // Remove current highlight
+        if (currentHighlightIndex >= 0 && currentHighlightIndex < marks.length) {
+            marks[currentHighlightIndex].classList.remove('current');
+        }
+
+        if (currentHighlightIndex < 0) {
+            currentHighlightIndex = direction > 0 ? 0 : marks.length - 1;
+        } else {
+            currentHighlightIndex += direction;
+            if (currentHighlightIndex >= marks.length) currentHighlightIndex = 0;
+            if (currentHighlightIndex < 0) currentHighlightIndex = marks.length - 1;
+        }
+
+        marks[currentHighlightIndex].classList.add('current');
+        marks[currentHighlightIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
+        updateHighlightNav();
+    }
+
+    function clearHighlights() {
+        document.querySelectorAll('mark.search-hit').forEach(mark => {
+            const text = document.createTextNode(mark.textContent);
+            mark.parentNode.replaceChild(text, mark);
+        });
+        currentHighlightIndex = -1;
+        document.getElementById('highlight-nav').classList.add('hidden');
     }
 
     function groupSessions(sessions) {
@@ -427,12 +634,21 @@
 
     function renderSidebar(sessions) {
         const query = document.getElementById('search').value.toLowerCase();
-        const filtered = query
-            ? sessions.filter(s =>
+        let filtered;
+
+        if (searchMode === 'content' && contentSearchResults) {
+            // Content search mode: show only sessions with hits
+            const hitSessionIds = new Set(contentSearchResults.map(r => r.session_id));
+            filtered = sessions.filter(s => hitSessionIds.has(s.id));
+        } else if (searchMode === 'session' && query) {
+            // Session name mode: incremental filter (existing behavior)
+            filtered = sessions.filter(s =>
                 s.display_name.toLowerCase().includes(query) ||
                 s.first_text.toLowerCase().includes(query) ||
-                s.project.toLowerCase().includes(query))
-            : sessions;
+                s.project.toLowerCase().includes(query));
+        } else {
+            filtered = sessions;
+        }
 
         const byProject = groupSessions(filtered);
         let html = '';
@@ -589,7 +805,17 @@
             document.getElementById('session-title').textContent = currentSession.display_name;
         }
     });
-    document.getElementById('search').addEventListener('input', () => renderSidebar(allSessions));
+    document.getElementById('search').addEventListener('input', () => {
+        if (searchMode === 'session') {
+            renderSidebar(allSessions);
+        }
+        // Content mode: no incremental search, wait for Enter
+    });
+    document.getElementById('search').addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && searchMode === 'content') {
+            executeContentSearch(e.target.value);
+        }
+    });
     document.getElementById('rename-btn').addEventListener('click', openRenameModal);
     document.getElementById('rename-close').addEventListener('click', () => document.getElementById('rename-modal').classList.add('hidden'));
     document.getElementById('rename-cancel').addEventListener('click', () => document.getElementById('rename-modal').classList.add('hidden'));


### PR DESCRIPTION
## Summary

- メッセージ本文の横断検索を実装（closes #12）
- タブUIで「セッション名」「本文」検索モードを切り替え
- セッション名モード: 既存のインクリメンタル検索（動作変更なし）
- 本文モード: Enter確定 → バックエンドAPI `/api/search` を呼び出し → ヒットセッションで絞り込み
- セッション表示時にヒット箇所を黄色ハイライト
- チャットエリア右下にフローティングジャンプナビ（↑↓ / 件数表示 / ✕クリア）

## 設計判断

- **モード切り替えを先に選ばせる**: セッション名にマッチしないが本文に含まれるケースで、インクリメンタル絞り込みと混在すると「あるはずのセッションが消える」体験になるため
- **本文検索はEnter確定**: 全セッションのJSONL走査が重いため、1文字ごとの実行を避ける
- **将来拡張**: 検索結果ビュー（スニペット一覧表示）への拡張を見据え、APIはスニペット付きで返す設計

## Test plan

- [x] セッション名タブ: 既存の検索が従来通り動作すること
- [x] 本文タブ: Enter確定で検索が実行されること
- [x] ヒットしたセッションのみサイドバーに表示されること
- [x] セッションを開くとヒット箇所がハイライトされること
- [x] フローティングナビで↑↓ジャンプが動作すること
- [x] タブ切り替え時に検索状態がリセットされること
- [ ] EN/JA切り替えでプレースホルダーが変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)