### PR TITLE
Scroll to latest message on session load

### DIFF
--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -482,6 +482,9 @@
         if (searchMode === 'content' && contentSearchQuery && contentSearchQuery.length >= 2) {
             applyHighlights(contentSearchQuery);
         }
+
+        // Scroll to latest message after render completes
+        requestAnimationFrame(() => { chat.scrollTop = chat.scrollHeight; });
     }
 
     // --- Search mode & content search ---


### PR DESCRIPTION
## Summary

- Auto-scroll to the bottom (latest message) when opening a session
- Uses `requestAnimationFrame` to ensure DOM rendering completes before scrolling

## Test plan

- [ ] Open a long session → view starts at the latest message
- [ ] Open a short session → works normally
- [ ] Playback mode still starts from top (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)