### PR TITLE
言語切替時にチャット内容も再レンダリング

### DIFF
--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -1013,6 +1013,7 @@
         renderSidebar(allSessions);
         if (currentSession) {
             document.getElementById('session-title').textContent = currentSession.display_name;
+            loadSession(currentSession);
         }
     });
     document.getElementById('search').addEventListener('input', () => {


### PR DESCRIPTION
## Summary

- 言語切替時に `loadSession()` を再実行し、日付セパレーター・タイムスタンプを新しい言語で再描画

## Test plan

- [ ] 言語切替でチャット内の日付・タイムスタンプが切り替わる
- [ ] サイドバーのセッション一覧も切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)