### PR TITLE
[feat] アーカイブ対応・セッションID表示・退避ガイド

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ package.json
 # Editor
 .idea/
 .vscode/
+
+# Archives (keep directory, ignore log files)
+archives/**/*.jsonl

--- a/README.md
+++ b/README.md
@@ -92,9 +92,30 @@ Open the playback panel with the ▼ toggle in the header, then press ▶ to rep
 - **⏹** — stop and show all messages instantly
 - **Speed slider** — drag to adjust playback speed (0.05x slow to 4x fast)
 
+### Session log retention & archiving
+
+Claude Code automatically deletes session logs older than **30 days** by default. To preserve important sessions, you can:
+
+1. **Extend or disable the cleanup** — add to `~/.claude/settings.json`:
+   ```json
+   "cleanupPeriodDays": 90
+   ```
+   Set to `0` to disable automatic deletion entirely (watch disk usage).
+
+2. **Archive sessions manually** — copy `.jsonl` files to the `archives/` directory (or any folder of your choice), then register the path in the config:
+   ```
+   ~/.config/claude-log-viewer/config.json
+   ```
+   ```json
+   {
+     "extra_paths": ["/path/to/your/archives"]
+   }
+   ```
+   Archived sessions will appear in the sidebar alongside active ones. Use the **session ID** shown in the header (click to copy) to identify which files to archive.
+
 ### Adding custom session files
 
-Place any `.jsonl` files under a subdirectory of `~/.claude/projects/`, then click the reload button in the UI.
+Place any `.jsonl` files under a subdirectory of `~/.claude/projects/` (or an `extra_paths` directory), then click the reload button in the UI.
 
 ```
 ~/.claude/projects/
@@ -207,9 +228,30 @@ alias clv='source ~/claude-log-viewer/.venv/bin/activate && claude-log-viewer'
 - **⏹** — 停止して全メッセージを即時表示
 - **速度スライダー** — ドラッグして再生速度を調整（0.05x〜4x）
 
+### セッションログの保持期間と退避
+
+Claude Code はデフォルトで **30日** 経過したセッションログを自動削除します。大事なセッションを残すには：
+
+1. **自動削除の期間を延長・無効化** — `~/.claude/settings.json` に追加：
+   ```json
+   "cleanupPeriodDays": 90
+   ```
+   `0` にすると自動削除を無効化できます（ディスク容量に注意）。
+
+2. **手動で退避** — `.jsonl` ファイルを `archives/` ディレクトリ（または任意のフォルダ）にコピーし、config にパスを登録：
+   ```
+   ~/.config/claude-log-viewer/config.json
+   ```
+   ```json
+   {
+     "extra_paths": ["/path/to/your/archives"]
+   }
+   ```
+   退避したセッションもサイドバーに表示されます。ヘッダーに表示される **セッションID**（クリックでコピー可能）を使って、退避するファイルを特定できます。
+
 ### カスタムファイルの追加
 
-`~/.claude/projects/` 以下の任意のサブフォルダに `.jsonl` ファイルを置いて、UIのリロードボタンを押すと左サイドバーに表示されます。
+`~/.claude/projects/`（または `extra_paths` で指定したディレクトリ）以下の任意のサブフォルダに `.jsonl` ファイルを置いて、UIのリロードボタンを押すと左サイドバーに表示されます。
 
 ```
 ~/.claude/projects/

--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -146,6 +146,7 @@
             <!-- Row 2: Token badge + Quote + Reload + Playback toggle -->
             <div id="header-row2" class="hidden items-center gap-2 px-4 md:px-6 h-9 border-t border-zinc-100 dark:border-zinc-800/50">
                 <span id="token-badge" class="hidden px-2 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-[10px] font-mono text-zinc-500 dark:text-zinc-400 flex-shrink-0 whitespace-nowrap"></span>
+                <span id="session-id-badge" class="hidden px-2 py-0.5 rounded bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-[10px] font-mono text-zinc-400 dark:text-zinc-500 flex-shrink-0 cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors truncate max-w-[18ch]" onclick="copySessionId()" title="Click to copy session ID"></span>
                 <div class="flex-1"></div>
                 <button id="quote-mode-btn" class="flex-shrink-0 p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" onclick="toggleQuoteMode()" title="Quote mode">
                     <i class="ph ph-quotes text-sm"></i>
@@ -642,6 +643,18 @@
         }
     }
 
+    function copySessionId() {
+        const badge = document.getElementById('session-id-badge');
+        const fullId = badge.dataset.fullId;
+        if (!fullId) return;
+        copyToClipboard(fullId).then(() => {
+            const orig = badge.textContent;
+            badge.textContent = t('copied');
+            setTimeout(() => { badge.textContent = orig; }, 1200);
+        });
+    }
+    window.copySessionId = copySessionId;
+
     async function reloadSession() {
         if (!currentSession) return;
         const btn = document.getElementById('reload-btn');
@@ -667,6 +680,12 @@
         titleEl.title = session.display_name || session.id;
         document.getElementById('token-badge').classList.add('hidden');
         document.getElementById('rename-btn').classList.remove('hidden');
+        // Show session ID badge
+        const idBadge = document.getElementById('session-id-badge');
+        idBadge.textContent = session.id.slice(0, 8);
+        idBadge.title = session.id;
+        idBadge.dataset.fullId = session.id;
+        idBadge.classList.remove('hidden');
         // Show header row 2
         const row2 = document.getElementById('header-row2');
         row2.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- `archives/` ディレクトリを追加（`extra_paths`で退避先として利用可能）
- ヘッダー2段目にセッションIDバッジ追加（先頭8文字表示、クリックでフルIDコピー）
- README: ログ自動削除（30日）の説明、`cleanupPeriodDays`設定、手動退避方法を追記（EN/JA）
- `.gitignore`: archives内の.jsonlファイルを除外

## Test plan
- [x] セッションIDバッジの表示確認
- [x] クリックでIDコピー動作確認
- [x] archives/ が .gitkeep で維持されること
- [x] README EN/JA 両方に退避ガイド追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)