### PR TITLE
[fix] セッションIDをファイル名形式で表示+コピー改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,13 @@ Claude Code automatically deletes session logs older than **30 days** by default
      "extra_paths": ["/path/to/your/archives"]
    }
    ```
-   Archived sessions will appear in the sidebar alongside active ones. Use the **session ID** shown in the header (click to copy) to identify which files to archive.
+   Archived sessions will appear in the sidebar alongside active ones. Use the **session filename** shown in the header (click to copy) to identify which files to archive.
+
+   Each session consists of a `.jsonl` file and optionally a folder with the same name (containing subagent logs). Copy both when archiving:
+   ```bash
+   cp ~/.claude/projects/<project>/<session-id>.jsonl archives/<project>/
+   cp -r ~/.claude/projects/<project>/<session-id>/ archives/<project>/  # if exists
+   ```
 
 ### Adding custom session files
 
@@ -247,7 +253,13 @@ Claude Code はデフォルトで **30日** 経過したセッションログを
      "extra_paths": ["/path/to/your/archives"]
    }
    ```
-   退避したセッションもサイドバーに表示されます。ヘッダーに表示される **セッションID**（クリックでコピー可能）を使って、退避するファイルを特定できます。
+   退避したセッションもサイドバーに表示されます。ヘッダーに表示される **セッションファイル名**（クリックでコピー可能）を使って、退避するファイルを特定できます。
+
+   各セッションは `.jsonl` ファイルと、同名のフォルダ（サブエージェントのログ）で構成されます。退避時は両方をコピーしてください：
+   ```bash
+   cp ~/.claude/projects/<project>/<session-id>.jsonl archives/<project>/
+   cp -r ~/.claude/projects/<project>/<session-id>/ archives/<project>/  # 存在する場合
+   ```
 
 ### カスタムファイルの追加
 

--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -146,7 +146,10 @@
             <!-- Row 2: Token badge + Quote + Reload + Playback toggle -->
             <div id="header-row2" class="hidden items-center gap-2 px-4 md:px-6 h-9 border-t border-zinc-100 dark:border-zinc-800/50">
                 <span id="token-badge" class="hidden px-2 py-0.5 rounded bg-zinc-100 dark:bg-zinc-800 border border-zinc-200 dark:border-zinc-700 text-[10px] font-mono text-zinc-500 dark:text-zinc-400 flex-shrink-0 whitespace-nowrap"></span>
-                <span id="session-id-badge" class="hidden px-2 py-0.5 rounded bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-[10px] font-mono text-zinc-400 dark:text-zinc-500 flex-shrink-0 cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors truncate max-w-[18ch]" onclick="copySessionId()" title="Click to copy session ID"></span>
+                <span id="session-id-badge" class="hidden items-center gap-1 px-2 py-0.5 rounded bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-[10px] font-mono text-zinc-400 dark:text-zinc-500 flex-shrink-0 cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors" onclick="copySessionId()" title="Click to copy filename">
+                    <i class="ph ph-file-text"></i>
+                    <span id="session-id-text"></span>
+                </span>
                 <div class="flex-1"></div>
                 <button id="quote-mode-btn" class="flex-shrink-0 p-1.5 rounded-md text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" onclick="toggleQuoteMode()" title="Quote mode">
                     <i class="ph ph-quotes text-sm"></i>
@@ -645,12 +648,13 @@
 
     function copySessionId() {
         const badge = document.getElementById('session-id-badge');
+        const textEl = document.getElementById('session-id-text');
         const fullId = badge.dataset.fullId;
         if (!fullId) return;
-        copyToClipboard(fullId).then(() => {
-            const orig = badge.textContent;
-            badge.textContent = t('copied');
-            setTimeout(() => { badge.textContent = orig; }, 1200);
+        copyToClipboard(fullId + '.jsonl').then(() => {
+            const orig = textEl.textContent;
+            textEl.textContent = t('copied');
+            setTimeout(() => { textEl.textContent = orig; }, 1200);
         });
     }
     window.copySessionId = copySessionId;
@@ -682,10 +686,11 @@
         document.getElementById('rename-btn').classList.remove('hidden');
         // Show session ID badge
         const idBadge = document.getElementById('session-id-badge');
-        idBadge.textContent = session.id.slice(0, 8);
-        idBadge.title = session.id;
+        document.getElementById('session-id-text').textContent = session.id.slice(0, 8) + '.jsonl';
+        idBadge.title = session.id + '.jsonl';
         idBadge.dataset.fullId = session.id;
         idBadge.classList.remove('hidden');
+        idBadge.classList.add('flex');
         // Show header row 2
         const row2 = document.getElementById('header-row2');
         row2.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- セッションIDバッジをファイルアイコン + `xxxxxxxx.jsonl` 形式で表示
- クリックコピー時に `.jsonl` 拡張子を自動付与
- README: `.jsonl` + 同名フォルダ（subagents）のセット退避手順を追記（EN/JA）

🤖 Generated with [Claude Code](https://claude.com/claude-code)