### PR TITLE
PC表示時にサイドバーをトグルで表示/非表示できる機能を追加

### DIFF
--- a/claude_log_viewer/templates/index.html
+++ b/claude_log_viewer/templates/index.html
@@ -49,6 +49,9 @@
         .dark .speed-slider::-webkit-slider-thumb { background: #d97d54; }
         .speed-slider::-webkit-slider-thumb { background: #d97d54; }
 
+        /* Sidebar collapse (PC) */
+        aside.sidebar-collapsed { width: 0; overflow: hidden; border-right-width: 0; padding: 0; }
+
         /* Long text wrap (URLs etc) */
         .msg-wrap { overflow-wrap: anywhere; word-break: break-word; }
 
@@ -135,8 +138,8 @@
         <header class="flex flex-col border-b border-zinc-200 dark:border-zinc-800 bg-white/80 dark:bg-[#09090b]/80 backdrop-blur-lg sticky top-0 z-10 transition-colors duration-300">
             <!-- Row 1: Title + Rename -->
             <div class="flex items-center gap-2 px-4 md:px-6 h-11 min-w-0">
-                <button id="sidebar-toggle" class="p-1.5 rounded-md text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors md:hidden" onclick="toggleSidebar()" title="Open sidebar">
-                    <i class="ph ph-list text-lg"></i>
+                <button id="sidebar-toggle" class="w-7 h-7 flex items-center justify-center rounded-md border border-zinc-300 dark:border-zinc-700 text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" onclick="toggleSidebar()" title="Toggle sidebar">
+                    <i id="sidebar-toggle-icon" class="ph ph-caret-left text-sm"></i>
                 </button>
                 <h1 id="session-title" class="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate min-w-0" data-i18n="select_session">Select a session</h1>
                 <button id="rename-btn" class="hidden flex-shrink-0 p-1 rounded text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors" title="Rename session">
@@ -228,18 +231,52 @@
 
 
     <script>
+    function updateSidebarIcon() {
+        const sidebar = document.getElementById('sidebar');
+        const icon = document.getElementById('sidebar-toggle-icon');
+        const isMobile = window.innerWidth < 768;
+        const isCollapsed = isMobile
+            ? sidebar.classList.contains('-translate-x-full')
+            : sidebar.classList.contains('sidebar-collapsed');
+        icon.className = isCollapsed
+            ? 'ph ph-caret-right text-lg'
+            : 'ph ph-caret-left text-lg';
+    }
+
     function toggleSidebar() {
         const sidebar = document.getElementById('sidebar');
         const overlay = document.getElementById('sidebar-overlay');
-        const isOpen = !sidebar.classList.contains('-translate-x-full');
-        if (isOpen) {
-            sidebar.classList.add('-translate-x-full');
-            overlay.classList.add('hidden');
+        const isMobile = window.innerWidth < 768;
+
+        if (isMobile) {
+            // Mobile: slide in/out with overlay
+            const isOpen = !sidebar.classList.contains('-translate-x-full');
+            if (isOpen) {
+                sidebar.classList.add('-translate-x-full');
+                overlay.classList.add('hidden');
+            } else {
+                sidebar.classList.remove('-translate-x-full');
+                overlay.classList.remove('hidden');
+            }
         } else {
-            sidebar.classList.remove('-translate-x-full');
-            overlay.classList.remove('hidden');
+            // PC: collapse width with animation
+            const isCollapsed = sidebar.classList.contains('sidebar-collapsed');
+            if (isCollapsed) {
+                sidebar.classList.remove('sidebar-collapsed');
+                localStorage.setItem('sidebar_collapsed', 'false');
+            } else {
+                sidebar.classList.add('sidebar-collapsed');
+                localStorage.setItem('sidebar_collapsed', 'true');
+            }
         }
+        updateSidebarIcon();
     }
+
+    // Restore sidebar state on PC
+    if (window.innerWidth >= 768 && localStorage.getItem('sidebar_collapsed') === 'true') {
+        document.getElementById('sidebar').classList.add('sidebar-collapsed');
+    }
+    updateSidebarIcon();
 
     const selectedMessages = new Set();
     let quoteMode = false;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+annotated-doc==0.0.4
+annotated-types==0.7.0
+anyio==4.13.0
+click==8.3.2
+fastapi==0.136.0
+h11==0.16.0
+idna==3.11
+pydantic==2.13.2
+pydantic_core==2.46.2
+starlette==1.0.0
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+uvicorn==0.44.0


### PR DESCRIPTION
## 概要
PC表示時にサイドバーを折りたたみ/展開できるトグル機能を追加。状態はlocalStorageで永続化され、ページ再読み込み後も維持される。モバイル表示は既存のスライド動作を維持。

## 変更内容
- sidebar-collapsed CSSクラスによるPC向けサイドバー折りたたみ
- トグルボタンをモバイル・PC両方で常時表示に変更
- キャレット矢印アイコンで開閉状態を視覚的に表現
- localStorageによる折りたたみ状態の永続化
- requirements.txtの追加（依存関係の明示化）

## チェックリスト
- [x] タチコマ検証: セキュリティ問題なし
- [x] ロジコマ クロスレビュー: スキップ（L1: フロントエンドUI変更のみ）
- [ ] テスト: 手動確認推奨（PC/モバイル両方でのトグル動作）